### PR TITLE
Error checking on open

### DIFF
--- a/libnfs/__init__.py
+++ b/libnfs/__init__.py
@@ -62,9 +62,12 @@ class NFSFH(object):
 
         self._nfsfh = new_NFSFileHandle()
         if _mode & os.O_CREAT:
-            nfs_create(self._nfs, path, _mode, 0664, self._nfsfh)
+            _status = nfs_create(self._nfs, path, _mode, 0664, self._nfsfh)
         else:
-            nfs_open(self._nfs, path, _mode, self._nfsfh)
+            _status = nfs_open(self._nfs, path, _mode, self._nfsfh)
+        if _status != 0:
+            _errmsg = "open failed: %s" % (os.strerror(-_status),)
+            raise ValueError(_errmsg)
         self._nfsfh = NFSFileHandle_value(self._nfsfh)
         self._closed = False
         self._need_flush = False

--- a/libnfs/__init__.py
+++ b/libnfs/__init__.py
@@ -113,7 +113,7 @@ class NFSFH(object):
 
     def seek(self, offset, whence=os.SEEK_CUR):
         _pos = new_uint64_t_ptr()
-        nfs_lseek(self._nfs, self._nfsfh, offset, os.whence, _pos)
+        nfs_lseek(self._nfs, self._nfsfh, offset, whence, _pos)
 
     def truncate(self, offset=-1):
         if offset < 0:


### PR DESCRIPTION
Because of a bug in my NFS server, nfs_create was failing but NFSFH.open appeared to succeed.  The file handle was uninitialized and this made libnfs dump core on subsequent operations.  I have changed it to raise a ValueError exception if the return value is nonzero.  I will probably add similar checks to the other operations.