### PR TITLE
added struct timeval definition to interface file

### DIFF
--- a/libnfs/libnfs.i
+++ b/libnfs/libnfs.i
@@ -36,6 +36,11 @@ struct nfs_context;
 struct AUTH;
 struct nfsfh;
 
+struct timeval {
+        uint64_t tv_sec;
+        uint64_t tv_usec;
+};
+
 struct nfs_url {
 	char *server;
 	char *path;


### PR DESCRIPTION
As discussed in issue #11 was unable to get mtime, ctime, atime values for nfsdirent. 
This problem is solved by adding struct timeval definition to the libnfs.i file. Since nfsdirent contains a struct timeval variable (and not a struct timeval*) pointer, we will need to add struct timeval definition to libnfs.i
