### PR TITLE
bugfix for isfile or isdir  function

### DIFF
--- a/libnfs/__init__.py
+++ b/libnfs/__init__.py
@@ -16,6 +16,7 @@
 import errno
 import os
 import sys
+import stat
 from .libnfs import *
 
 def _stat_to_dict(stat):


### PR DESCRIPTION
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/mnt/qjjia/cloudml/cloud-ml/restful_server/venv/lib/python2.7/site-packages/libnfs/__init__.py", line 256, in isfile
    return stat.S_ISREG(st.nfs_mode)
NameError: global name 'stat' is not defined