### PR TITLE
Fix missing NFS rename argument

### DIFF
--- a/libnfs/__init__.py
+++ b/libnfs/__init__.py
@@ -268,7 +268,7 @@ class NFS(object):
 
     def rename(self, src, dst):
         """Rename file"""
-        ret = nfs_rename(src, dst)
+        ret = nfs_rename(self._nfs, src, dst)
         if ret == -errno.ENOENT:
             raise IOError(errno.ENOENT, 'No such file or directory')
         return ret


### PR DESCRIPTION
Hey,
the `nfs.rename` function was not passing the context struct to `nfs_rename`.

I've tested it and the fix works.